### PR TITLE
feat: allow overriding issuer_url with a static value from environment variable

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -119,7 +119,7 @@ const handleOpenidConfiguration = (req, res) => {
 const handleJwks =
 	({jwk: {kty, alg, kid, e, n}}) =>
 	(req, res) =>
-		res.json({keys: [{kty, alg, kid, e, n}]});
+		res.json({keys: [{use: 'sig', kty, alg, kid, e, n}]});
 
 const handleAuthorize =
 	({users, codes, sessions}) =>

--- a/src/server.js
+++ b/src/server.js
@@ -28,7 +28,7 @@ const createToken = () => randomBytes(16).toString('base64url');
 const encodeVerifier = (verifier, challengeMethod) =>
 	challengeMethod === 'S256' ? createHash('sha256').update(verifier).digest('base64url') : verifier;
 
-const getIssuer = (req) => `${req.protocol}://${req.headers.host}/`; // ending in '/' for Auth0 compatibility
+const getIssuer = (req) => process.env.ISSUER_URL || `${req.protocol}://${req.headers.host}/`; // ending in '/' for Auth0 compatibility
 
 const buildBaseClaims = (req, ttl, aud) => {
 	const iss = getIssuer(req);


### PR DESCRIPTION
Under certain scenarios, it is desirable to allow for a predictable ISSUER_URL value as we might have the mock server accessible thru different routes (eg.: via nginx with a host header and directly thru docker or k8s mesh) and add use: 'sig' field to jwks url result to make it compatible with ory oathkeeper