### PR TITLE
fix: accept client_secret_basic on the token endpoint

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -42,6 +42,33 @@ const encodeVerifier = (verifier, challengeMethod) =>
 			? createHash('sha256').update(verifier).digest('base64url')
 			: verifier;
 
+// RFC 6749 §2.3.1: both values are form-urlencoded before the pair is encoded for basic authentication
+const decodeCredential = (value) => decodeURIComponent(value.replace(/\+/g, ' '));
+
+// client_secret_post carries the client id in the body, client_secret_basic in the authorization header;
+// the secret itself is never checked, since any secret is accepted for a mock client
+const getClientId = (req) => {
+	const {client_id: clientId} = req.body;
+	if (typeof clientId === 'string') {
+		return clientId;
+	}
+	const header = req.headers.authorization;
+	if (!header || !/^Basic /i.test(header)) {
+		return undefined;
+	}
+	const decoded = Buffer.from(header.slice(6), 'base64').toString('utf8');
+	// the secret may contain colons of its own, so only the first one separates the two values
+	const separator = decoded.indexOf(':');
+	if (separator === -1) {
+		return undefined;
+	}
+	try {
+		return decodeCredential(decoded.slice(0, separator));
+	} catch {
+		return undefined; // malformed percent-encoding leaves no id to look up
+	}
+};
+
 // req.protocol and req.host follow the X-Forwarded-* headers, see the 'trust proxy' setting
 const getIssuer = (req, issuer) => issuer || `${req.protocol}://${req.host}/`; // ending in '/' for Auth0 compatibility
 
@@ -238,9 +265,11 @@ const handleToken =
 	({users, clients, codes, sessions, ttl, issuer, jwk, signingKey}) =>
 	(req, res) => {
 		res.setHeader('Cache-Control', 'no-store');
+		// the client picks the authentication method, so the id does not always arrive in the body
+		const aud = getClientId(req);
 		switch (req.body.grant_type) {
 			case 'authorization_code': {
-				const {client_id: aud, code, code_verifier: verifier} = req.body;
+				const {code, code_verifier: verifier} = req.body;
 				const data = codes.get(code);
 				if (!data) {
 					return res.status(401).json({error: 'invalid_request', error_description: 'Code not found'});
@@ -260,8 +289,8 @@ const handleToken =
 				return sendToken(req, res, session, issuer, jwk, signingKey, ttl, aud, scope, nonce);
 			}
 			case 'client_credentials': {
-				const {client_id: clientId, scope} = req.body;
-				const client = clients.find((client) => client.sub === clientId);
+				const {scope} = req.body;
+				const client = clients.find((client) => client.sub === aud);
 				if (!client) {
 					return res.status(401).json({error: 'invalid_client', error_description: 'Client not found'});
 				}
@@ -272,7 +301,7 @@ const handleToken =
 				);
 			}
 			case 'password': {
-				const {username: sub, scope, client_id: aud} = req.body;
+				const {username: sub, scope} = req.body;
 				const user = users.find((user) => user.sub === sub);
 				if (!user) {
 					return res.status(401).json({error: 'invalid_request', error_description: 'User not found'});
@@ -284,7 +313,7 @@ const handleToken =
 				return sendToken(req, res, session, issuer, jwk, signingKey, ttl, aud, scope);
 			}
 			case 'refresh_token': {
-				const {client_id: aud, refresh_token: refreshToken, scope} = req.body;
+				const {refresh_token: refreshToken, scope} = req.body;
 				// the token identifies the session; a cookie is not available to clients refreshing from a server
 				const session = sessions.values().find((s) => s.token && s.token === refreshToken);
 				if (!session) {

--- a/test/clients.yaml
+++ b/test/clients.yaml
@@ -1,0 +1,2 @@
+# a client id that has to survive a round trip through form encoding
+- sub: my service

--- a/test/token.test.js
+++ b/test/token.test.js
@@ -3,12 +3,20 @@
 const {after, before, describe, test} = require('node:test');
 const assert = require('node:assert/strict');
 const {createHash} = require('node:crypto');
+const {join} = require('node:path');
 
 const {startServer, CookieJar, request, decodeJwt, approve, getTokens} = require('./helpers');
 
 const challengeFor = (verifier) => createHash('sha256').update(verifier).digest('base64url');
 const token = (base, form, jar) => request(base, '/oauth/token', {form, jar});
 const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// RFC 6749 §2.3.1: the credentials are form-urlencoded before they are encoded for basic authentication
+const basicAuth = (clientId, clientSecret = 'any') =>
+	`Basic ${Buffer.from(`${encodeURIComponent(clientId)}:${encodeURIComponent(clientSecret)}`).toString('base64')}`;
+
+const tokenAs = (base, form, authorization) =>
+	request(base, '/oauth/token', {form, headers: {Authorization: authorization}});
 
 describe('the authorization code grant', () => {
 	let server;
@@ -124,6 +132,12 @@ describe('the password grant', () => {
 		const response = await token(server.base, {grant_type: 'password', username: 'nobody', client_id: 'baz'});
 		assert.equal(response.status, 401);
 	});
+
+	test('takes the audience from the authorization header', async () => {
+		const response = await tokenAs(server.base, {grant_type: 'password', username: 'foo'}, basicAuth('baz'));
+		const tokens = await response.json();
+		assert.equal(decodeJwt(tokens.id_token).aud, 'baz');
+	});
 });
 
 describe('the client credentials grant', () => {
@@ -146,6 +160,50 @@ describe('the client credentials grant', () => {
 	test('rejects an unknown client', async () => {
 		const response = await token(server.base, {grant_type: 'client_credentials', client_id: 'nobody'});
 		assert.equal(response.status, 401);
+	});
+
+	// RFC 6749 §2.3.1 calls basic authentication the preferred method, and discovery advertises it as supported
+	test('accepts the client id from the authorization header', async () => {
+		const response = await tokenAs(server.base, {grant_type: 'client_credentials'}, basicAuth('baz'));
+		assert.equal(response.status, 200);
+		const tokens = await response.json();
+		assert.equal(decodeJwt(tokens.access_token).sub, 'baz');
+	});
+
+	test('rejects an unknown client from the authorization header', async () => {
+		const response = await tokenAs(server.base, {grant_type: 'client_credentials'}, basicAuth('nobody'));
+		assert.equal(response.status, 401);
+	});
+
+	// the secret may contain a colon of its own, so only the first one separates the two values
+	test('accepts a secret containing a colon', async () => {
+		const response = await tokenAs(server.base, {grant_type: 'client_credentials'}, basicAuth('baz', 'a:b:c'));
+		assert.equal(response.status, 200);
+	});
+
+	test('rejects a malformed authorization header without failing', async () => {
+		const response = await tokenAs(server.base, {grant_type: 'client_credentials'}, 'Basic bm8tc2VwYXJhdG9y');
+		assert.equal(response.status, 401);
+	});
+});
+
+describe('client ids that need encoding', () => {
+	let server;
+	before(async () => (server = await startServer(['--clients', join(__dirname, 'clients.yaml')])));
+	after(() => server.stop());
+
+	// RFC 6749 §2.3.1 form-urlencodes both values before they are encoded, so the provider has to decode them again
+	test('decodes an encoded client id from the authorization header', async () => {
+		const response = await tokenAs(server.base, {grant_type: 'client_credentials'}, basicAuth('my service'));
+		assert.equal(response.status, 200);
+		assert.equal(decodeJwt(await response.json().then((t) => t.access_token)).sub, 'my service');
+	});
+
+	// form encoding writes a space as '+', which a client library may well produce instead of '%20'
+	test('decodes a plus in the client id as a space', async () => {
+		const encoded = Buffer.from('my+service:any').toString('base64');
+		const response = await tokenAs(server.base, {grant_type: 'client_credentials'}, `Basic ${encoded}`);
+		assert.equal(response.status, 200);
 	});
 });
 


### PR DESCRIPTION
Closes #31.

## The problem

`/oauth/token` only ever read `client_id` from the request body, so a client authenticating with HTTP basic authentication got `401 {"error":"invalid_client","error_description":"Client not found"}` — even though discovery advertises the method as supported:

```json
"token_endpoint_auth_methods_supported": ["client_secret_basic", "client_secret_post"]
```

[RFC 6749 §2.3.1](https://www.rfc-editor.org/rfc/rfc6749#section-2.3.1) calls basic authentication the preferred method and several client libraries default to it, so those clients could not use the client credentials grant at all.

## The fix

A new `getClientId(req)` prefers `req.body.client_id` and falls back to decoding the `Authorization: Basic` header. Details worth a look during review:

- only the **first** colon separates the pair, so a secret containing colons does not truncate the client id
- both halves are form-urldecoded (`+` to space, then `decodeURIComponent`) as §2.3.1 requires, wrapped in a `try`/`catch` so malformed percent-encoding returns no id rather than throwing a 500
- the scheme match is case-insensitive, and a header with no colon falls through to the usual 401

The secret is still never validated. Any secret is accepted, which is what `client_secret_post` already did for these mock clients.

## Slightly wider than the issue

The id is resolved **once for all four grants** rather than only in `client_credentials`. The same body parameter fed the `aud` claim for `authorization_code`, `password`, and `refresh_token`, so a basic-authenticating client was silently receiving tokens with no audience. Same root cause, so it is fixed in one place.

## Testing

The tests were written first and confirmed failing against the unfixed server (all five returned 401, or a missing `aud`). Two negative cases are included to keep the parsing from being too permissive, plus a `test/clients.yaml` fixture with a client id containing a space to cover the decoding path.

Full suite: **65 passing, 0 failing**; `npm run lint` and prettier clean. The repro from #31 was also run against a live server — `client_secret_basic` now returns a token with `"sub":"baz"`, and an unknown client over basic auth still returns `401 invalid_client`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)